### PR TITLE
Updated Windows building instructions.

### DIFF
--- a/ports/windows/README.md
+++ b/ports/windows/README.md
@@ -12,7 +12,7 @@ Build instruction assume you're in the ports/windows directory.
 Building on Debian/Ubuntu Linux system
 ---------------------------------------
 
-    sudo apt-get install python3 build-essential gcc-mingw-w64
+    sudo apt-get install python3 build-essential gcc-mingw-w64 git
     make -C ../../mpy-cross
     make submodules
     make CROSS_COMPILE=i686-w64-mingw32-
@@ -27,6 +27,7 @@ Install Cygwin, then install following packages using Cygwin's setup.exe:
 * mingw64-x86_64-gcc-core
 * make
 * python3
+* git
 
 Build using:
 
@@ -48,7 +49,7 @@ Install MSYS2 from http://repo.msys2.org/distrib, start the msys2.exe shell and
 install the build tools:
 
     pacman -Syuu
-    pacman -S make mingw-w64-x86_64-gcc pkg-config python3
+    pacman -S make mingw-w64-x86_64-gcc pkg-config python3 git
 
 Start the mingw64.exe shell and build:
 


### PR DESCRIPTION
Added missing "make submodules" commands in the building instructions and "git" as a required package.