### PR TITLE
Avoid division by zero in run-perfbench.py

### DIFF
--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -146,7 +146,7 @@ def run_benchmarks(args, target, param_n, param_m, n_average, test_list):
                 error = "FAIL self"
                 break
             times.append(time)
-            scores.append(1e6 * norm / time)
+            scores.append(0 if time == 0 else 1e6 * norm / time)
 
         # Check result against truth if needed
         if error is None and result_out != "None":
@@ -170,7 +170,10 @@ def run_benchmarks(args, target, param_n, param_m, n_average, test_list):
             s_avg, s_sd = compute_stats(scores)
             print(
                 "{:.2f} {:.4f} {:.2f} {:.4f}".format(
-                    t_avg, 100 * t_sd / t_avg, s_avg, 100 * s_sd / s_avg
+                    t_avg, 
+                    0 if t_avg == 0 else 100 * t_sd / t_avg, 
+                    s_avg,
+                    0 if s_avg == 0 else 100 * s_sd / s_avg
                 )
             )
             if 0:


### PR DESCRIPTION
I run-perfbench.py to compare different builds of MicroPython (MSYS2 MINGW64, MSVC Debug, MSVC Release, ...) on Windows 11.

The "MSVC Release" version caused a "ZeroDivisionError: float division by zero" when benchmarking `core_import_mpy_single.py`, and this patch avoids that issue.

I'm not 100% sure that this is the best or even correct way to solve this, so your comments are appreciated.

Here's what was happening before:
```
> set MICROPY_MICROPYTHON=../ports/windows/build-standard/ReleaseWin32/micropython.exe

> python run-perfbench.py 3500 10000 | tee w32VS-rel.txt
[-----8<-----]
perf_bench/core_import_mpy_multi.py: 6271.25 6.9512 80121.33 7.0677
Traceback (most recent call last):
  File "C:\micropython\tests\run-perfbench.py", line 321, in <module>
perf_bench/core_import_mpy_single.py:     main()
  File "C:\micropython\tests\run-perfbench.py", line 310, in main
    target_had_error = run_benchmarks(args, target, N, M, n_average, tests)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\micropython\tests\run-perfbench.py", line 149, in run_benchmarks
    scores.append(1e6 * norm / time)
                  ~~~~~~~~~~~^~~~~~
ZeroDivisionError: float division by zero
```

... and after the patch:
```
> python run-perfbench.py --emit bytecode 3500 10000 | tee w32VS-rel.txt
[-----8<-----]
perf_bench/core_import_mpy_multi.py: 6458.50 4.9809 77608.98 4.9673
perf_bench/core_import_mpy_single.py: 117.12 264.5751 133.40 264.5751
[-----8<-----]
```